### PR TITLE
Removes getFederationToken from tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,8 +190,6 @@ upload.testcreds = function(callback) {
         return callback(new Error('env var AWS_ACCESS_KEY_ID required'));
     if (!process.env.AWS_SECRET_ACCESS_KEY)
         return callback(new Error('env var AWS_SECRET_ACCESS_KEY required'));
-    if (!process.env.AWS_SESSION_TOKEN)
-        return callback(new Error('env var AWS_SESSION_TOKEN required'));
     var sts = new AWS.STS({ region:'us-east-1' });
 
     callback(null, {

--- a/test/test.js
+++ b/test/test.js
@@ -197,13 +197,11 @@ describe('upload.getcreds', function() {
         function cb(err, c){
             assert.ifError(err);
             assert.equal(c.bucket, 'mapbox-upload-testing');
-            assert.deepEqual(Object.keys(c), [
-                'bucket',
-                'key',
-                'accessKeyId',
-                'secretAccessKey',
-                'sessionToken'
-            ]);
+            var keys = Object.keys(c);
+            assert.ok(keys.indexOf('bucket') > -1);
+            assert.ok(keys.indexOf('key') > -1);
+            assert.ok(keys.indexOf('accessKeyId') > -1);
+            assert.ok(keys.indexOf('secretAccessKey') > -1);
             done && done() || (done = false);
         };
         upload.getcreds(opts(), prog, cb);


### PR DESCRIPTION
Instead of making a getFederationToken call, rely on user having proper permissions in their environment.

cc @willwhite 
