### PR TITLE
Update aws-sdk to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "progress-stream": "0.5.0",
     "request": "2.48.x",
     "s3-upload-stream": "0.6.x",
-    "aws-sdk": "1.18.0"
+    "aws-sdk": "2.0.29"
   },
   "devDependencies": {
     "retire": "0.3.x",


### PR DESCRIPTION
Would be great to update the aws-sdk dep. Any reason not to do this?

Why I'm aiming for this now: mapbox-upload is unnecessarily increasing the size of mbstudio because it pulls in a 17 MB aws-sdk install. Recent versions of aws-sdk are now much smaller: around 2.7 MB after https://github.com/aws/aws-sdk-js/issues/233
