### PR TITLE
Add decache querystring to getcreds requests

### DIFF
--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -222,6 +222,13 @@ test('upload.getcreds failed no bucket', function(t) {
     });
 });
 
+test('upload.getcreds failed cached response', function(t) {
+    upload.getcreds(opts({ mapbox: 'http://localhost:3000/cached' }), function cb(err, creds) {
+        t.equal('Received cached credentials, retry upload', err.message);
+        t.end();
+    });
+});
+
 test('upload.getcreds good creds', function(t) {
     upload.getcreds(opts(), function cb(err, a) {
         t.ifError(err);

--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -233,13 +233,19 @@ test('upload.getcreds good creds', function(t) {
     upload.getcreds(opts(), function cb(err, a) {
         t.ifError(err);
         t.equal(a.bucket, 'mapbox-upload-testing');
-        t.deepEqual(Object.keys(a), ['bucket', 'key', 'accessKeyId', 'secretAccessKey', 'sessionToken']);
+        t.equal(typeof a.bucket, 'string');
+        t.equal(typeof a.key, 'string');
+        t.equal(typeof a.accessKeyId, 'string');
+        t.equal(typeof a.secretAccessKey, 'string');
 
         // Call getcreds again to ensure unique credentials on each call.
         upload.getcreds(opts(), function cb(err, b) {
             t.ifError(err);
             t.equal(b.bucket, 'mapbox-upload-testing');
-            t.deepEqual(Object.keys(b), ['bucket', 'key', 'accessKeyId', 'secretAccessKey', 'sessionToken']);
+            t.equal(typeof b.bucket, 'string');
+            t.equal(typeof b.key, 'string');
+            t.equal(typeof b.accessKeyId, 'string');
+            t.equal(typeof b.secretAccessKey, 'string');
             t.ok(a.key !== b.key, 'unique creds.key between calls');
             t.end();
         });


### PR DESCRIPTION
- Adds cache-busting query string that uses `crypto.pseudoRandomBytes` to ensure creds requests are not cached (e.g. `decache=bc7d42a4ed3d889be16ee8880dff4fcc`)
- Fails getcreds requests explicitly if they see a `X-Cache: Hit from cloudfront` header.
- Tests for all this.

cc @willwhite