### PR TITLE
Add support for Node v4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 node_js:
   - "0.10"
+  - "4.1"
 
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "mapbox-upload": "./bin/upload.js"
   },
   "engines": {
-    "node": "0.6.x || 0.8.x || 0.10.x"
+    "node": "0.6.x || 0.8.x || 0.10.x || 4.x"
   }
 }


### PR DESCRIPTION
I've been using mapbox-upload pretty successfully with Node 4.1.2 - this PR adds official support for Node 4.

Let me know if you think any codebase changes are in order!