### PR TITLE
validate name option, no invalid characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 4.2.2
+
+* add regular expression to catch invalid characters for the `name` option ([#58](https://github.com/mapbox/mapbox-upload/issues/58))

--- a/index.js
+++ b/index.js
@@ -38,6 +38,8 @@ upload.opts = function(opts) {
         throw new Error('"mapid" option required');
     if (opts.mapid.split('.')[0] !== opts.account)
         throw new Error(util.format('Invalid mapid "%s" for account "%s"', opts.mapid, opts.account));
+    if (! /^([\w-.]+)$/.test(opts.name))
+        throw new Error('"name" contains invalid characters');
     return opts;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-upload",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "main": "./index.js",
   "description": "Integration with MapBox upload API.",
   "repository": {

--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -436,7 +436,7 @@ test('cli - patch should fail since user doesnt have patch flag', function(t) {
     exec([__dirname + '/../bin/upload.js', options.mapid, options.file, '--patch'].join(' '), {
         env: process.env,
         timeout: 2000
-    }, function(err, stdout, stderr) {
+    }, function(err) {
         t.ok(/Error: Invalid property "patch"/.test(err.message));
         t.end();
     });

--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -136,7 +136,7 @@ test('setup', function(t) {
 });
 
 test('upload.opts', function(t) {
-    t.plan(6);
+    t.plan(7);
     t.throws(function() { upload.opts({}) }, /"file" or "stream" option required/);
     t.throws(function() { upload.opts({ file:'somepath' }) }, /"account" option required/);
     t.throws(function() { upload.opts({ file:'somepath', account:'test' }) }, /"accesstoken" option required/);

--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -142,6 +142,7 @@ test('upload.opts', function(t) {
     t.throws(function() { upload.opts({ file:'somepath', account:'test' }) }, /"accesstoken" option required/);
     t.throws(function() { upload.opts({ file:'somepath', account:'test', accesstoken:'validtoken' }) }, /"mapid" option required/);
     t.throws(function() { upload.opts({ file:'somepath', account:'test', accesstoken:'validtoken', mapid:'wrong.account' }) }, / Invalid mapid "wrong.account" for account "test"/);
+    t.throws(function() { upload.opts({ file:'somepath', account:'test', accesstoken:'validtoken', mapid:'test.upload', name: '../../name.file' }) }, 'opts.name: invalid characters');
     t.doesNotThrow(function() { upload.opts({ file:'somepath', account:'test', accesstoken:'validtoken', mapid:'test.upload' }) });
 });
 
@@ -436,8 +437,6 @@ test('cli - patch should fail since user doesnt have patch flag', function(t) {
         env: process.env,
         timeout: 2000
     }, function(err, stdout, stderr) {
-        console.log(stdout);
-        console.error(stderr);
         t.ok(/Error: Invalid property "patch"/.test(err.message));
         t.end();
     });
@@ -452,6 +451,18 @@ test('cli - empty name should fail', function(t) {
         timeout: 2000
     }, function(err, stdout) {
         t.ok(stdout.indexOf('please provide a name') !== -1);
+        t.end();
+    });
+});
+
+test('cli - invalid characters --name should fail', function(t) {
+    var options = opts({mapbox: 'http://localhost:3000'});
+    process.env.MapboxAccessToken = options.accesstoken;
+    exec([__dirname + '/../bin/upload.js', options.mapid, options.file, '--name "../../file.geojson"'].join(' '), {
+        env: process.env,
+        timeout: 2000
+    }, function(err, stdout, stderr) {
+        t.ok(stderr.indexOf('contains invalid characters') !== -1, 'invalid characters');
         t.end();
     });
 });


### PR DESCRIPTION
This adds a check for invalid characters in the `name` option. It will catch special characters, including file path slashes `/`. This fixes #58 

Two tests

* asserting an error is thrown from `index.js` for invalid name
* asserting invalid characters in `stderr` when using the CLI

cc/ @GretaCB @BergWerkGIS @rclark 