### PR TITLE
better error message for wrong scope tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,10 +72,15 @@ upload.getcreds = function(opts, callback) {
             return callback(err);
         }
         if (resp.statusCode !== 200) {
-            err = new Error(body && body.message || 'Mapbox is not available: ' + resp.statusCode);
+            if (body.message == 'Not Found') {
+                err = new Error('Invalid access token. Make sure your token has the uploads:write scope.');
+            } else {
+                err = new Error(body && body.message || 'Mapbox is not available: ' + resp.statusCode);
+            }
             err.code = resp.statusCode;
             return callback(err);
         }
+
         if (!body.key || !body.bucket) {
             return callback(new Error('Invalid creds'));
         } else if (resp.headers['x-cache'] === 'Hit from cloudfront') {

--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -317,7 +317,7 @@ test('upload.putfile good creds (file) - file can be accessed by authorized requ
                 Key: creds.key
             }, function(err, data) {
                 t.ifError(err);
-                t.equal('69632', data.ContentLength);
+                t.equal(69632, data.ContentLength);
                 t.ok(+new Date(data.LastModified) > +new Date - 60e3);
                 prog.called = true;
                 t.end();


### PR DESCRIPTION
This improves the error message for tokens that don't have the `uploads:write` scope. 

refs: #27 

