### PR TITLE
adding user agent to POST request for uploads api

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,8 @@ upload.createupload = function(url, opts, callback) {
         uri: uri,
         proxy: opts.proxy,
         headers: {
-            'Content-type': 'application/json'
+            'Content-type': 'application/json',
+            'User-Agent': 'mapbox-upload@' + require(__dirname + '/package.json').version
         },
         body: JSON.stringify({
             url: url,


### PR DESCRIPTION
Resolves #30 by adding a `User-Agent` header to the Uploads API `POST` request.

cc @willwhite 